### PR TITLE
Add repos.yaml

### DIFF
--- a/repo/packages/cray-mpich-binary/package.py
+++ b/repo/packages/cray-mpich-binary/package.py
@@ -1,0 +1,156 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+import spack.compilers
+from spack.package import *
+
+
+class CrayMpichBinary(Package):
+    """Install cray-mpich as a binary package"""
+
+    homepage = "https://www.hpe.com/us/en/compute/hpc/hpc-software.html"
+    url = "https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-8.1.18.4-gcc.tar.gz"
+
+    maintainers = ["haampie"]
+
+    version("8.1.21.1-gcc",
+            sha256="0a6852ebf06afd249285fd09566e8489300cba96ad66e90c40df36b6af9a631e",
+            url="https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-8.1.21.1-gcc.tar.gz")
+    version("8.1.21.1-nvhpc",
+            sha256="791b39f2ecb933060abaa8c8704e71da01c6962c4211cc99d12b9d964e9be4cb",
+            url="https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-8.1.21.1-nvhpc.tar.gz")
+    version("8.1.18.4-gcc",
+            sha256="776c695aeed62b3f64a1bca11b30a2537a907777a8664d2f092e3deac288e4ad",
+            url="https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-8.1.18.4-gcc.tar.gz")
+    version("8.1.18.4-nvhpc",
+            sha256="2285433363c75a04ccdf4798be5b0e296e0c9a8fb8fcb38eb0aa4ccf8d1e0843",
+            url="https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-8.1.18.4-nvhpc.tar.gz")
+
+    variant("cuda", default=False)
+    variant("rocm", default=False)
+
+    conflicts("+cuda", when="+rocm", msg="Pick either CUDA or ROCM")
+
+    provides("mpi")
+
+    # Fix up binaries with patchelf.
+    depends_on("patchelf", type="build")
+    with when("+cuda"):
+        # libcudart.so.11.0
+        depends_on("cuda@11.0:11", type="link")
+
+    with when("+rocm"):
+        # libamdhip64.so.5
+        depends_on("hip@5:", type="link")
+        # libhsa-runtime64.so.1
+        depends_on("hsa-rocr-dev", type="link")
+
+    # libfabric.so.1
+    depends_on("libfabric@1:", type="link")
+
+    with when("@8.1.21.1-gcc"):
+        # libgfortran.so.5
+        conflicts("%gcc@:7")
+        for __compiler in spack.compilers.supported_compilers():
+            if __compiler != "gcc":
+                conflicts("%{}".format(__compiler), msg="gcc required")
+
+    with when("@8.1.21.1-nvhpc"):
+        conflicts("%nvhpc@:20.6")
+        conflicts("+rocm")
+        conflicts("~cuda")
+        for __compiler in spack.compilers.supported_compilers():
+            if __compiler != "nvhpc":
+                conflicts("%{}".format(__compiler), msg="nvhpc required")
+
+    with when("@8.1.18.4-gcc"):
+        # libgfortran.so.5
+        conflicts("%gcc@:7")
+        for __compiler in spack.compilers.supported_compilers():
+            if __compiler != "gcc":
+                conflicts("%{}".format(__compiler), msg="gcc required")
+
+    with when("@8.1.18.4-nvhpc"):
+        conflicts("%nvhpc@:20.6")
+        conflicts("+rocm")
+        conflicts("~cuda")
+        for __compiler in spack.compilers.supported_compilers():
+            if __compiler != "nvhpc":
+                conflicts("%{}".format(__compiler), msg="nvhpc required")
+
+    # TODO: libpals.so.0? no clue where it comes from.
+
+    def setup_run_environment(self, env):
+        env.set("MPICC", join_path(self.prefix.bin, "mpicc"))
+        env.set("MPICXX", join_path(self.prefix.bin, "mpic++"))
+        env.set("MPIF77", join_path(self.prefix.bin, "mpif77"))
+        env.set("MPIF90", join_path(self.prefix.bin, "mpif90"))
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        self.setup_run_environment(env)
+        env.set("MPICH_CC", dependent_spec.package.module.spack_cc)
+        env.set("MPICH_CXX", dependent_spec.package.module.spack_cxx)
+        env.set("MPICH_FC", dependent_spec.package.module.spack_fc)
+
+    def setup_dependent_package(self, module, dependent_spec):
+        self.spec.mpicc = join_path(self.prefix.bin, "mpicc")
+        self.spec.mpicxx = join_path(self.prefix.bin, "mpic++")
+        self.spec.mpifc = join_path(self.prefix.bin, "mpif90")
+        self.spec.mpif77 = join_path(self.prefix.bin, "mpif77")
+
+    def get_rpaths(self):
+        # Those rpaths are already set in the build environment, so
+        # let's just retrieve them.
+        pkgs = os.getenv("SPACK_RPATH_DIRS", "").split(":")
+        compilers = os.getenv("SPACK_COMPILER_IMPLICIT_RPATHS", "").split(":")
+        return ":".join([p for p in pkgs + compilers if p])
+
+    def should_patch(self, file):
+        # Returns true if non-symlink ELF file.
+        if os.path.islink(file):
+            return False
+        try:
+            with open(file, "rb") as f:
+                return f.read(4) == b"\x7fELF"
+        except OSError:
+            return False
+
+    def install(self, spec, prefix):
+        install_tree(".", prefix)
+
+    @run_after("install")
+    def fixup_binaries(self):
+        patchelf = which("patchelf")
+        rpath = self.get_rpaths()
+        for root, _, files in os.walk(self.prefix):
+            for name in files:
+                f = os.path.join(root, name)
+                if not self.should_patch(f):
+                    continue
+                patchelf("--force-rpath", "--set-rpath", rpath, f, fail_on_error=False)
+
+    @run_after("install")
+    def fixup_compiler_paths(self):
+        filter_file("@@CC@@", self.compiler.cc, self.prefix.bin.mpicc, string=True)
+        filter_file("@@CXX@@", self.compiler.cxx, self.prefix.bin.mpicxx, string=True)
+        filter_file("@@FC@@", self.compiler.fc, self.prefix.bin.mpifort, string=True)
+
+        filter_file("@@PREFIX@@", self.prefix, self.prefix.bin.mpicc, string=True)
+        filter_file("@@PREFIX@@", self.prefix, self.prefix.bin.mpicxx, string=True)
+        filter_file("@@PREFIX@@", self.prefix, self.prefix.bin.mpifort, string=True)
+
+        # link with the relevant gtl lib
+        if "+cuda" in self.spec:
+            gtl_library = "-lmpi_gtl_cuda"
+        elif "+rocm" in self.spec:
+            gtl_library = "-lmpi_gtl_hsa"
+        else:
+            gtl_library = ""
+
+        filter_file("@@GTL_LIBRARY@@", gtl_library, self.prefix.bin.mpicc, string=True)
+        filter_file("@@GTL_LIBRARY@@", gtl_library, self.prefix.bin.mpicxx, string=True)
+        filter_file("@@GTL_LIBRARY@@", gtl_library, self.prefix.bin.mpifort, string=True)

--- a/repo/repo.yaml
+++ b/repo/repo.yaml
@@ -1,0 +1,2 @@
+repo:
+  namespace: alps

--- a/templates/Makefile.generate-config
+++ b/templates/Makefile.generate-config
@@ -20,8 +20,7 @@ $(CONFIG_DIR)/upstreams.yaml:
 	$(SPACK) config --scope=user add upstreams:system:install_tree:$(STORE)
 
 $(CONFIG_DIR)/packages.yaml:
-	[[ -f $(SPACK_SYSTEM_CONFIG_PATH)/packages.yaml ]] \
-    && cp $(SPACK_SYSTEM_CONFIG_PATH)/packages.yaml $(CONFIG_DIR)/packages.yaml
+	cp ../config/packages.yaml ../store/config/packages.yaml
 
 # Generate a configuration used to generate the module files
 # The configuration in CONFIG_DIR can't be used for this purpose, because a compilers.yaml

--- a/templates/Makefile.generate-config
+++ b/templates/Makefile.generate-config
@@ -19,8 +19,10 @@ $(CONFIG_DIR)/compilers.yaml:
 $(CONFIG_DIR)/upstreams.yaml:
 	$(SPACK) config --scope=user add upstreams:system:install_tree:$(STORE)
 
-$(CONFIG_DIR)/packages.yaml:
-	cp ../config/packages.yaml ../store/config/packages.yaml
+# Copy the cluster-specific packages.yaml file to the configuration.
+# requires compilers.yaml to ensure that the path $(CONFIG_DIR) has been created.
+$(CONFIG_DIR)/packages.yaml: $(CONFIG_DIR)/compilers.yaml
+-...cp $(SOFTWARE_STACK_PROJECT)/config/packages.yaml $(CONFIG_DIR)/packages.yaml
 
 # Generate a configuration used to generate the module files
 # The configuration in CONFIG_DIR can't be used for this purpose, because a compilers.yaml

--- a/templates/Makefile.generate-config
+++ b/templates/Makefile.generate-config
@@ -5,23 +5,30 @@ MODULE_DIR = $(SOFTWARE_STACK_PROJECT)/modules
 
 # These will be the prefixes of the GCCs, LLVMs and NVHPCs in the respective environments.
 ALL_COMPILER_PREFIXES ={% for compiler in all_compilers %} $$($(SPACK) -e ../compilers/{{ compiler }} find --format='{prefix}' gcc llvm nvhpc){% endfor %}
+
+
 COMPILER_PREFIXES ={% for compiler in release_compilers %} $$($(SPACK) -e ../compilers/{{ compiler }} find --format='{prefix}' gcc llvm nvhpc){% endfor %}
 
-all: $(CONFIG_DIR)/upstreams.yaml $(CONFIG_DIR)/compilers.yaml $(MODULE_DIR)/upstreams.yaml $(MODULE_DIR)/compilers.yaml
 
-# Generate the compiler config file
+all: $(CONFIG_DIR)/upstreams.yaml $(CONFIG_DIR)/compilers.yaml $(CONFIG_DIR)/packages.yaml $(MODULE_DIR)/upstreams.yaml $(MODULE_DIR)/compilers.yaml
+
+# Generate the upstream configuration that will be provided by the mounted image
 $(CONFIG_DIR)/compilers.yaml:
 	$(SPACK) compiler find --scope=user $(call compiler_bin_dirs, $(COMPILER_PREFIXES))
 
-# Generate the upstreams config file
 $(CONFIG_DIR)/upstreams.yaml:
 	$(SPACK) config --scope=user add upstreams:system:install_tree:$(STORE)
 
-# Generate the compiler config file
+$(CONFIG_DIR)/packages.yaml:
+	[[ -f $(SPACK_SYSTEM_CONFIG_PATH)/packages.yaml ]] \
+    && cp $(SPACK_SYSTEM_CONFIG_PATH)/packages.yaml $(CONFIG_DIR)/packages.yaml
+
+# Generate a configuration used to generate the module files
+# The configuration in CONFIG_DIR can't be used for this purpose, because a compilers.yaml
+# that includes the bootstrap compiler is required to build the modules.
 $(MODULE_DIR)/compilers.yaml:
 	$(SPACK) compiler find --scope=user $(call compiler_bin_dirs, $(ALL_COMPILER_PREFIXES))
 
-# Generate the upstreams config file
 $(MODULE_DIR)/upstreams.yaml:
 	$(SPACK) config --scope=user add upstreams:system:install_tree:$(STORE)
 

--- a/templates/repos.yaml
+++ b/templates/repos.yaml
@@ -1,0 +1,2 @@
+repos:
+- {{ repo_path }}

--- a/test/base-nvgpu/config.yaml
+++ b/test/base-nvgpu/config.yaml
@@ -4,3 +4,5 @@ system: hohgant
 spack:
     repo: https://github.com/spack/spack.git
     commit: 6408b51
+mirror:
+    enable: false

--- a/test/unique-bootstrap/packages.yaml
+++ b/test/unique-bootstrap/packages.yaml
@@ -1,4 +1,14 @@
 packages:
+    mpi:
+      compiler:
+          toolchain: gcc
+          spec: gcc@12
+      unify: true
+      specs:
+      - cuda@11.8
+      - osu-micro-benchmarks@5.9
+      mpi: cray-mpich-binary
+      gpu: cuda
     tools:
       compiler:
           toolchain: gcc


### PR DESCRIPTION
Provide CSCS-specific packages to downstream consumers by adding a Spack repo:

* a `repo/` path is added to the image
  * currently contains one package: `cray-mpich-binary`
* `repos.yaml` is added to the `store/` path, so downstream spack instances can find `cray-mpich-binary`
* the repo is also used when building the image, instead of the current hacking of the builtin spack packages

Fixes #4